### PR TITLE
Added Nix integration scripts

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -10,18 +10,15 @@ curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=$RUST_TOOLCHAIN -y
 # Load cargo environment. Specifically, put cargo into PATH.
 source ~/.cargo/env
 
-rustup install nightly-2019-05-21
-rustup target add wasm32-unknown-unknown --toolchain nightly-2019-05-21
-rustup override set nightly
-
 rustc --version
 rustup --version
 cargo --version
 
 case $TARGET in
 	"native")
+
 		sudo apt-get -y update
-		sudo apt-get install -y cmake pkg-config libssl-dev
+		sudo apt-get install -y cmake pkg-config libssl-dev clang libclang-dev
 
 		./scripts/init.sh
 		cargo build
@@ -38,4 +35,5 @@ case $TARGET in
 		cd ../deposit && cargo test
 		cd ../predicate && cargo test
 		;;
+
 esac

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,16 @@
+{ nixpkgs ? import ./nixpkgs.nix { }
+, rustWasm
+}:
+
+with nixpkgs;
+with llvmPackages_latest;
+
+rustPlatform.buildRustPackage rec {
+  name = "plasm-node";
+  src = ./..;
+  cargoSha256 = null; 
+  buildInputs = [ rustWasm wasm-gc pkgconfig openssl clang ];
+  LIBCLANG_PATH = "${libclang}/lib";
+  # FIXME: we can remove this once prost is updated.
+  PROTOC = "${protobuf}/bin/protoc";
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,7 @@
+{ moz_overlay ? import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz)
+, nixpkgs ? import (builtins.fetchTarball https://github.com/nixos/nixpkgs-channels/archive/nixos-19.09.tar.gz)
+}:
+
+nixpkgs {
+  overlays = [ moz_overlay ];
+}

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,0 +1,14 @@
+{ nixpkgs ? import ./nixpkgs.nix { }
+}:
+
+with nixpkgs;
+
+let
+  channel = rustChannelOf { date = "2019-09-03"; channel = "nightly"; };
+
+in rec {
+  rustWasm = channel.rust.override {
+    targets = [ "wasm32-unknown-unknown" ];
+  };
+  plasm-node = callPackage ./. { inherit rustWasm; };
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,15 @@
+{ nixpkgs ? import ./nixpkgs.nix { }
+, release ? import ./release.nix { }
+}:
+
+with nixpkgs;
+with release;
+with llvmPackages_latest;
+
+stdenv.mkDerivation {
+  name = "plasm-nix-shell";
+  buildInputs = [ rustWasm wasm-gc pkgconfig openssl clang ];
+  LIBCLANG_PATH = "${libclang}/lib";
+  # FIXME: we can remove this once prost is updated.
+  PROTOC = "${protobuf}/bin/protoc";
+}


### PR DESCRIPTION

## Affected core subsystem(s)
<!-- Please provide affected other system(s). -->
No

## Description of change
<!-- Please provide a description of the change here. -->
* Added build & development support for NixOS systems (https://nixos.org/).
* Nix (https://nixos.org/nix/) package manager integration scripts placed in `nix` directory.

## Usage examples

Start development environment with nightly wasm enabled rust compiler:

```bash
~/Plasm $ nix-shell ./nix/shell.nix
```